### PR TITLE
feat : load mf schemes data on startup if not exists

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <java.version>21</java.version>
         <vaadin.version>24.4.8</vaadin.version>
         <spring-modulith.version>1.2.2</spring-modulith.version>
+        <org.mapstruct.version>1.6.0</org.mapstruct.version>
 
         <spotless.version>2.43.0</spotless.version>
     </properties>
@@ -87,6 +88,11 @@
             <groupId>org.springframework.modulith</groupId>
             <artifactId>spring-modulith-core</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+            <version>${org.mapstruct.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -122,6 +128,21 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${org.mapstruct.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                    <release>${java.version}</release>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/src/main/java/com/example/application/config/RestClientConfiguration.java
+++ b/src/main/java/com/example/application/config/RestClientConfiguration.java
@@ -19,7 +19,7 @@ public class RestClientConfiguration {
     RestClientCustomizer restClientCustomizer() {
         return restClientBuilder -> restClientBuilder.defaultHeaders(httpHeaders -> {
             httpHeaders.setContentType(MediaType.APPLICATION_JSON);
-            httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON));
+            httpHeaders.setAccept(List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN));
         });
     }
 }

--- a/src/main/java/com/example/application/mfschemes/MFSchemeDTO.java
+++ b/src/main/java/com/example/application/mfschemes/MFSchemeDTO.java
@@ -1,0 +1,4 @@
+package com.example.application.mfschemes;
+
+public record MFSchemeDTO(
+        String amc, Long schemeCode, String isin, String schemeName, String nav, String date, String schemeType) {}

--- a/src/main/java/com/example/application/mfschemes/bootstrap/Initializer.java
+++ b/src/main/java/com/example/application/mfschemes/bootstrap/Initializer.java
@@ -1,0 +1,125 @@
+package com.example.application.mfschemes.bootstrap;
+
+import com.example.application.mfschemes.MFSchemeDTO;
+import com.example.application.mfschemes.entities.MFScheme;
+import com.example.application.mfschemes.mapper.MfSchemeDtoToEntityMapper;
+import com.example.application.mfschemes.service.MfSchemeService;
+import com.example.application.mfschemes.util.SchemeConstants;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class Initializer {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Initializer.class);
+    private final RestClient restClient;
+    private final MfSchemeService mfSchemeService;
+    private final MfSchemeDtoToEntityMapper mfSchemeDtoToEntityMapper;
+
+    public Initializer(
+            RestClient restClient,
+            MfSchemeService mfSchemeService,
+            MfSchemeDtoToEntityMapper mfSchemeDtoToEntityMapper) {
+        this.restClient = restClient;
+        this.mfSchemeService = mfSchemeService;
+        this.mfSchemeDtoToEntityMapper = mfSchemeDtoToEntityMapper;
+    }
+
+    @EventListener(ApplicationStartedEvent.class)
+    public void handleApplicationStartedEvent() {
+        LOGGER.info("Loading all Mutual Funds");
+        long start = System.currentTimeMillis();
+        try {
+            String allNAVs = restClient
+                    .get()
+                    .uri(SchemeConstants.AMFI_WEBSITE_LINK)
+                    .headers(HttpHeaders::clearContentHeaders)
+                    .header(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_PLAIN_VALUE)
+                    .retrieve()
+                    .body(String.class);
+            Reader inputString = new StringReader(Objects.requireNonNull(allNAVs));
+            List<MFSchemeDTO> chopArrayList = new ArrayList<>();
+            try (BufferedReader br = new BufferedReader(inputString)) {
+                String lineValue = br.readLine();
+                for (int i = 0; i < 2; ++i) {
+                    lineValue = br.readLine();
+                }
+                String schemeType = lineValue;
+                String amc = lineValue;
+                while (lineValue != null) {
+                    boolean nonAmcRow = true;
+                    String[] tokenize = lineValue.split(SchemeConstants.NAV_SEPARATOR);
+                    boolean processRowByForce = false;
+                    if (tokenize.length == 1) {
+                        nonAmcRow = false;
+                        String tempVal = lineValue;
+                        lineValue = br.readLine();
+                        if (!StringUtils.hasText(lineValue)) {
+                            lineValue = br.readLine();
+                            tokenize = lineValue.split(SchemeConstants.NAV_SEPARATOR);
+                            if (tokenize.length == 1) {
+                                schemeType = tempVal;
+                                amc = lineValue;
+                            } else {
+                                amc = tempVal;
+                                processRowByForce = true;
+                            }
+                        }
+                    }
+                    if (nonAmcRow || processRowByForce) {
+                        final String schemecode = tokenize[0];
+                        final String payout = tokenize[1];
+                        final String reinvestment = tokenize[2];
+                        final String schemename = tokenize[3];
+                        final String nav = tokenize[4];
+                        final String date = tokenize[5];
+                        final MFSchemeDTO tempObj = new MFSchemeDTO(
+                                amc, Long.valueOf(schemecode), payout, schemename, nav, date, schemeType);
+                        chopArrayList.add(tempObj);
+                    }
+                    lineValue = br.readLine();
+                    if (!StringUtils.hasText(lineValue)) {
+                        lineValue = br.readLine();
+                    }
+                }
+            }
+            LOGGER.info(
+                    "All Funds loaded in {} milliseconds, total funds loaded :{}",
+                    (System.currentTimeMillis() - start),
+                    chopArrayList.size());
+            if (mfSchemeService.count() != chopArrayList.size()) {
+                StopWatch stopWatch = new StopWatch();
+                stopWatch.start("saving fundNames");
+                List<MFScheme> list = new ArrayList<>();
+                List<Long> schemeCodesList = mfSchemeService.findAllSchemeIds();
+                chopArrayList.removeIf(s -> schemeCodesList.contains(s.schemeCode()));
+                chopArrayList.forEach(scheme -> {
+                    MFScheme mfSchemeEntity = mfSchemeDtoToEntityMapper.mapMFSchemeDTOToMFSchemeEntity(scheme);
+                    list.add(mfSchemeEntity);
+                });
+                mfSchemeService.saveAllEntities(list);
+                stopWatch.stop();
+                LOGGER.info("saved in db in : {} sec", stopWatch.getTotalTimeSeconds());
+            }
+        } catch (HttpClientErrorException | ResourceAccessException | IOException httpClientErrorException) {
+            LOGGER.error("Failed to load all Funds", httpClientErrorException);
+        }
+    }
+}

--- a/src/main/java/com/example/application/mfschemes/entities/Auditable.java
+++ b/src/main/java/com/example/application/mfschemes/entities/Auditable.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public abstract class Auditable<T> {
+abstract class Auditable<T> {
 
     @CreatedBy
     protected T createdBy;

--- a/src/main/java/com/example/application/mfschemes/entities/MFScheme.java
+++ b/src/main/java/com/example/application/mfschemes/entities/MFScheme.java
@@ -39,7 +39,7 @@ public class MFScheme extends Auditable<String> implements Serializable {
     @JoinColumn(name = "mf_scheme_type_id")
     private MFSchemeType mfSchemeType = null;
 
-    @OneToMany(mappedBy = "mfSchemeEntity", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "mfScheme", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MFSchemeNav> mfSchemeNavs = new ArrayList<>();
 
     @Version
@@ -119,7 +119,7 @@ public class MFScheme extends Auditable<String> implements Serializable {
 
     public MFScheme addSchemeNav(MFSchemeNav mfSchemeNav) {
         mfSchemeNavs.add(mfSchemeNav);
-        mfSchemeNav.setMfSchemeEntity(this);
+        mfSchemeNav.setMfScheme(this);
         return this;
     }
 }

--- a/src/main/java/com/example/application/mfschemes/entities/MFScheme.java
+++ b/src/main/java/com/example/application/mfschemes/entities/MFScheme.java
@@ -37,10 +37,10 @@ public class MFScheme extends Auditable<String> implements Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mf_scheme_type_id")
-    private MFSchemeType mfSchemeTypeEntity = null;
+    private MFSchemeType mfSchemeType = null;
 
     @OneToMany(mappedBy = "mfSchemeEntity", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MFSchemeNav> mfSchemeNavEntities = new ArrayList<>();
+    private List<MFSchemeNav> mfSchemeNavs = new ArrayList<>();
 
     @Version
     private Short version;
@@ -90,21 +90,21 @@ public class MFScheme extends Auditable<String> implements Serializable {
         return this;
     }
 
-    public MFSchemeType getMfSchemeTypeEntity() {
-        return mfSchemeTypeEntity;
+    public MFSchemeType getMfSchemeType() {
+        return mfSchemeType;
     }
 
-    public MFScheme setMfSchemeTypeEntity(MFSchemeType mfSchemeTypeEntity) {
-        this.mfSchemeTypeEntity = mfSchemeTypeEntity;
+    public MFScheme setMfSchemeType(MFSchemeType mfSchemeType) {
+        this.mfSchemeType = mfSchemeType;
         return this;
     }
 
-    public List<MFSchemeNav> getMfSchemeNavEntities() {
-        return mfSchemeNavEntities;
+    public List<MFSchemeNav> getMfSchemeNavs() {
+        return mfSchemeNavs;
     }
 
-    public MFScheme setMfSchemeNavEntities(List<MFSchemeNav> mfSchemeNavEntities) {
-        this.mfSchemeNavEntities = mfSchemeNavEntities;
+    public MFScheme setMfSchemeNavs(List<MFSchemeNav> mfSchemeNavs) {
+        this.mfSchemeNavs = mfSchemeNavs;
         return this;
     }
 
@@ -117,9 +117,9 @@ public class MFScheme extends Auditable<String> implements Serializable {
         return this;
     }
 
-    public MFScheme addSchemeNav(MFSchemeNav mfSchemeNavEntity) {
-        mfSchemeNavEntities.add(mfSchemeNavEntity);
-        mfSchemeNavEntity.setMfSchemeEntity(this);
+    public MFScheme addSchemeNav(MFSchemeNav mfSchemeNav) {
+        mfSchemeNavs.add(mfSchemeNav);
+        mfSchemeNav.setMfSchemeEntity(this);
         return this;
     }
 }

--- a/src/main/java/com/example/application/mfschemes/entities/MFSchemeNav.java
+++ b/src/main/java/com/example/application/mfschemes/entities/MFSchemeNav.java
@@ -31,7 +31,7 @@ public class MFSchemeNav extends Auditable<String> implements Serializable {
     @Column(name = "id", nullable = false)
     private Long id;
 
-    @Column(precision = 10, scale = 4)
+    @Column(precision = 12, scale = 4)
     private BigDecimal nav;
 
     @Column(name = "nav_date")
@@ -39,7 +39,7 @@ public class MFSchemeNav extends Auditable<String> implements Serializable {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mf_scheme_id")
-    private MFScheme mfSchemeEntity;
+    private MFScheme mfScheme;
 
     public Long getId() {
         return id;
@@ -68,12 +68,12 @@ public class MFSchemeNav extends Auditable<String> implements Serializable {
         return this;
     }
 
-    public MFScheme getMfSchemeEntity() {
-        return mfSchemeEntity;
+    public MFScheme getMfScheme() {
+        return mfScheme;
     }
 
-    public MFSchemeNav setMfSchemeEntity(MFScheme mfSchemeEntity) {
-        this.mfSchemeEntity = mfSchemeEntity;
+    public MFSchemeNav setMfScheme(MFScheme mfSchemeEntity) {
+        this.mfScheme = mfSchemeEntity;
         return this;
     }
 
@@ -91,8 +91,7 @@ public class MFSchemeNav extends Auditable<String> implements Serializable {
         MFSchemeNav that = (MFSchemeNav) o;
         return Objects.equals(getNav(), that.getNav())
                 && Objects.equals(
-                        getMfSchemeEntity().getSchemeId(),
-                        that.getMfSchemeEntity().getSchemeId())
+                        getMfScheme().getSchemeId(), that.getMfScheme().getSchemeId())
                 && Objects.deepEquals(getNavDate(), that.getNavDate());
     }
 

--- a/src/main/java/com/example/application/mfschemes/entities/MFSchemeType.java
+++ b/src/main/java/com/example/application/mfschemes/entities/MFSchemeType.java
@@ -17,9 +17,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Table(
-        name = "mf_scheme_types",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"scheme_type", "scheme_category"}))
+@Table(name = "mf_scheme_types", uniqueConstraints = @UniqueConstraint(columnNames = {"type", "category"}))
 public class MFSchemeType extends Auditable<String> implements Serializable {
 
     @Id
@@ -40,8 +38,8 @@ public class MFSchemeType extends Auditable<String> implements Serializable {
     @Version
     private Short version;
 
-    @OneToMany(mappedBy = "mfSchemeTypeEntity", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<MFScheme> mfSchemeEntities = new ArrayList<>();
+    @OneToMany(mappedBy = "mfSchemeType", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MFScheme> mfSchemes = new ArrayList<>();
 
     public Integer getSchemeTypeId() {
         return schemeTypeId;
@@ -88,18 +86,18 @@ public class MFSchemeType extends Auditable<String> implements Serializable {
         return this;
     }
 
-    public List<MFScheme> getMfSchemeEntities() {
-        return mfSchemeEntities;
+    public List<MFScheme> getMfSchemes() {
+        return mfSchemes;
     }
 
-    public MFSchemeType setMfSchemeEntities(List<MFScheme> mfSchemeEntities) {
-        this.mfSchemeEntities = mfSchemeEntities;
+    public MFSchemeType setMfSchemes(List<MFScheme> mfSchemeEntities) {
+        this.mfSchemes = mfSchemeEntities;
         return this;
     }
 
-    public void addMFScheme(MFScheme mfSchemeEntity) {
-        mfSchemeEntities.add(mfSchemeEntity);
-        mfSchemeEntity.setMfSchemeTypeEntity(this);
+    public void addMFScheme(MFScheme mfScheme) {
+        mfSchemes.add(mfScheme);
+        mfScheme.setMfSchemeType(this);
     }
 
     @Override

--- a/src/main/java/com/example/application/mfschemes/mapper/MfSchemeDtoToEntityMapper.java
+++ b/src/main/java/com/example/application/mfschemes/mapper/MfSchemeDtoToEntityMapper.java
@@ -1,0 +1,28 @@
+package com.example.application.mfschemes.mapper;
+
+import com.example.application.mfschemes.MFSchemeDTO;
+import com.example.application.mfschemes.entities.MFScheme;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+
+@Mapper(
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        uses = MfSchemeDtoToEntityMapperHelper.class,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface MfSchemeDtoToEntityMapper {
+
+    @Mapping(target = "version", ignore = true)
+    @Mapping(target = "mfSchemeType", ignore = true)
+    @Mapping(target = "mfSchemeNavs", ignore = true)
+    @Mapping(target = "schemeNameAlias", ignore = true)
+    @Mapping(target = "lastModifiedDate", ignore = true)
+    @Mapping(target = "lastModifiedBy", ignore = true)
+    @Mapping(target = "fundHouse", source = "amc")
+    @Mapping(target = "createdDate", ignore = true)
+    @Mapping(target = "createdBy", ignore = true)
+    @Mapping(target = "payOut", source = "isin")
+    @Mapping(target = "schemeId", source = "schemeCode")
+    MFScheme mapMFSchemeDTOToMFSchemeEntity(MFSchemeDTO mfSchemeDTO);
+}

--- a/src/main/java/com/example/application/mfschemes/mapper/MfSchemeDtoToEntityMapperHelper.java
+++ b/src/main/java/com/example/application/mfschemes/mapper/MfSchemeDtoToEntityMapperHelper.java
@@ -1,0 +1,83 @@
+package com.example.application.mfschemes.mapper;
+
+import com.example.application.mfschemes.MFSchemeDTO;
+import com.example.application.mfschemes.entities.MFScheme;
+import com.example.application.mfschemes.entities.MFSchemeNav;
+import com.example.application.mfschemes.entities.MFSchemeType;
+import com.example.application.mfschemes.repository.MFSchemeTypeRepository;
+import com.example.application.mfschemes.util.SchemeConstants;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.MappingTarget;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionTemplate;
+
+@Component
+public class MfSchemeDtoToEntityMapperHelper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MfSchemeDtoToEntityMapperHelper.class);
+
+    // Define the regular expressions
+    private static final Pattern TYPE_CATEGORY_SUBCATEGORY_PATTERN =
+            Pattern.compile("^([^()]+)\\(([^()]+)\\s*-\\s*([^()]+)\\)$");
+
+    private final MFSchemeTypeRepository mfSchemeTypeRepository;
+    private final TransactionTemplate transactionTemplate;
+
+    public MfSchemeDtoToEntityMapperHelper(
+            MFSchemeTypeRepository mfSchemeTypeRepository, TransactionTemplate transactionTemplate) {
+        this.mfSchemeTypeRepository = mfSchemeTypeRepository;
+        transactionTemplate.setPropagationBehaviorName("PROPAGATION_REQUIRES_NEW");
+        this.transactionTemplate = transactionTemplate;
+    }
+
+    @AfterMapping
+    void updateMFScheme(MFSchemeDTO scheme, @MappingTarget MFScheme mfScheme) {
+        MFSchemeNav mfSchemeNav = new MFSchemeNav();
+        mfSchemeNav.setNav(
+                "N.A.".equals(scheme.nav()) ? BigDecimal.ZERO : BigDecimal.valueOf(Double.parseDouble(scheme.nav())));
+        // Use the flexible formatter to parse the date
+        LocalDate parsedDate = LocalDate.parse(scheme.date(), SchemeConstants.FLEXIBLE_DATE_FORMATTER);
+        mfSchemeNav.setNavDate(parsedDate);
+        mfScheme.addSchemeNav(mfSchemeNav);
+
+        MFSchemeType mfSchemeType = null;
+        String schemeType = scheme.schemeType();
+        Matcher matcher = TYPE_CATEGORY_SUBCATEGORY_PATTERN.matcher(schemeType);
+        if (matcher.find()) {
+            String type = matcher.group(1).strip();
+            String category = matcher.group(2).strip();
+            String subCategory = matcher.group(3).strip();
+            mfSchemeType = findOrCreateMFSchemeTypeEntity(type, category, subCategory);
+        } else {
+            if (!schemeType.contains("-")) {
+                String type = schemeType.substring(0, schemeType.indexOf('('));
+                String category = schemeType.substring(schemeType.indexOf('(') + 1, schemeType.length() - 1);
+                mfSchemeType = findOrCreateMFSchemeTypeEntity(type, category, null);
+            } else {
+                LOGGER.error("Unable to parse schemeType :{}", schemeType);
+            }
+        }
+        mfScheme.setMfSchemeType(mfSchemeType);
+    }
+
+    MFSchemeType findOrCreateMFSchemeTypeEntity(String type, String category, @Nullable String subCategory) {
+        MFSchemeType byTypeAndCategoryAndSubCategory =
+                mfSchemeTypeRepository.findByTypeAndCategoryAndSubCategory(type, category, subCategory);
+        if (byTypeAndCategoryAndSubCategory == null) {
+            MFSchemeType mfSchemeType = new MFSchemeType();
+            mfSchemeType.setType(type);
+            mfSchemeType.setCategory(category);
+            mfSchemeType.setSubCategory(subCategory);
+            byTypeAndCategoryAndSubCategory =
+                    transactionTemplate.execute(status -> mfSchemeTypeRepository.save(mfSchemeType));
+        }
+        return byTypeAndCategoryAndSubCategory;
+    }
+}

--- a/src/main/java/com/example/application/mfschemes/repository/MFSchemeRepository.java
+++ b/src/main/java/com/example/application/mfschemes/repository/MFSchemeRepository.java
@@ -1,0 +1,12 @@
+package com.example.application.mfschemes.repository;
+
+import com.example.application.mfschemes.entities.MFScheme;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface MFSchemeRepository extends JpaRepository<MFScheme, Long> {
+
+    @Query("select o.schemeId from MFScheme o")
+    List<Long> findAllSchemeIds();
+}

--- a/src/main/java/com/example/application/mfschemes/repository/MFSchemeTypeRepository.java
+++ b/src/main/java/com/example/application/mfschemes/repository/MFSchemeTypeRepository.java
@@ -1,0 +1,9 @@
+package com.example.application.mfschemes.repository;
+
+import com.example.application.mfschemes.entities.MFSchemeType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MFSchemeTypeRepository extends JpaRepository<MFSchemeType, Integer> {
+
+    MFSchemeType findByTypeAndCategoryAndSubCategory(String type, String category, String subCategory);
+}

--- a/src/main/java/com/example/application/mfschemes/service/MfSchemeService.java
+++ b/src/main/java/com/example/application/mfschemes/service/MfSchemeService.java
@@ -1,0 +1,31 @@
+package com.example.application.mfschemes.service;
+
+import com.example.application.mfschemes.entities.MFScheme;
+import com.example.application.mfschemes.repository.MFSchemeRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class MfSchemeService {
+
+    private final MFSchemeRepository mFSchemeRepository;
+
+    public MfSchemeService(MFSchemeRepository mFSchemeRepository) {
+        this.mFSchemeRepository = mFSchemeRepository;
+    }
+
+    public long count() {
+        return mFSchemeRepository.count();
+    }
+
+    public List<Long> findAllSchemeIds() {
+        return mFSchemeRepository.findAllSchemeIds();
+    }
+
+    @Transactional
+    public List<MFScheme> saveAllEntities(List<MFScheme> list) {
+        return mFSchemeRepository.saveAll(list);
+    }
+}

--- a/src/main/java/com/example/application/mfschemes/util/SchemeConstants.java
+++ b/src/main/java/com/example/application/mfschemes/util/SchemeConstants.java
@@ -1,0 +1,19 @@
+package com.example.application.mfschemes.util;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
+import java.util.Locale;
+
+public final class SchemeConstants {
+
+    public static final String AMFI_WEBSITE_LINK = "https://www.amfiindia.com/spages/NAVAll.txt";
+    public static final String NAV_SEPARATOR = ";";
+
+    public static final DateTimeFormatter FLEXIBLE_DATE_FORMATTER = new DateTimeFormatterBuilder()
+            .appendPattern("[yyyy-MM-dd]") // ISO_LOCAL_DATE
+            .appendPattern("[dd-MMM-yyyy]") // Custom format
+            .parseDefaulting(ChronoField.YEAR_OF_ERA, LocalDate.now().getYear()) // Default year to current year
+            .toFormatter(Locale.ENGLISH); // Ensure English locale for month names
+}

--- a/src/main/resources/db/changelog/migration/04-mf_scheme_nav.xml
+++ b/src/main/resources/db/changelog/migration/04-mf_scheme_nav.xml
@@ -19,7 +19,7 @@
             <column name="id" type="BIGINT" defaultValueSequenceNext="mf_scheme_nav_seq">
                 <constraints nullable="false" primaryKey="true" primaryKeyName="pk_mf_scheme_nav"/>
             </column>
-            <column name="nav" type="NUMERIC(10, 4)"/>
+            <column name="nav" type="NUMERIC(12, 4)"/>
             <column name="nav_date" type="DATE"/>
             <column name="mf_scheme_id" type="BIGINT"/>
             <column name="created_by" type="${string.type}"/>

--- a/src/test/java/com/example/application/SchemaValidationPostgresTest.java
+++ b/src/test/java/com/example/application/SchemaValidationPostgresTest.java
@@ -4,6 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.example.application.common.SQLContainersConfig;
 import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import jakarta.persistence.metamodel.EntityType;
+import jakarta.persistence.metamodel.Metamodel;
+import java.util.Set;
 import javax.sql.DataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,8 +22,27 @@ class SchemaValidationPostgresTest {
     @Autowired
     DataSource dataSource;
 
+    @PersistenceContext
+    private EntityManager entityManager;
+
     @Test
     void validateJpaMappingsWithDbSchema() {
         assertThat(dataSource).isNotNull().isInstanceOf(HikariDataSource.class);
+
+        // Verify entity-to-table mappings
+        Metamodel metamodel = entityManager.getMetamodel();
+        Set<EntityType<?>> entities = metamodel.getEntities();
+
+        for (EntityType<?> entity : entities) {
+            String entityName = entity.getName();
+            // Example assertion: Check if the table exists in the database
+            // You can execute a query to check if the table exists
+            boolean tableExists = entityManager
+                            .createQuery("SELECT count (1) FROM " + entityName)
+                            .getResultList()
+                            .size()
+                    >= 0;
+            assertThat(tableExists).isTrue();
+        }
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new data transfer object (DTO) for mutual fund schemes, enhancing data encapsulation.
  - Added a service layer for managing mutual fund schemes, providing methods for counting and retrieving scheme IDs.
  - Implemented repository interfaces for managing mutual fund schemes and types.
  - Added a utility class for constants and date formatting to streamline the application.

- **Improvements**
  - Updated `RestClient` to accept both JSON and plain text responses, increasing flexibility in handling data.
  - Enhanced mapping logic using the MapStruct library for better object transformation and reduced boilerplate code.
  
- **Tests**
  - Expanded schema validation tests to ensure JPA entity mappings align with the database schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->