### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,12 @@ on:
     branches: [ "main" ]
 
 permissions:
+  # Required for actions/cache on push & PR
+  actions: read
   contents: read
   pull-requests: write
-
+  # Needed by SonarCloud to publish commit statuses/checks
+  statuses: write
 jobs:
   build:
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/rajadilipkolli/hilla-folioman/security/code-scanning/12](https://github.com/rajadilipkolli/hilla-folioman/security/code-scanning/12)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for interacting with pull requests (if necessary).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions for Maven builds to enhance security and define access scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->