### PR TITLE
feat: expose Portfolio Summary Endpoint

### DIFF
--- a/src/main/java/com/app/folioman/config/redis/CacheNames.java
+++ b/src/main/java/com/app/folioman/config/redis/CacheNames.java
@@ -16,6 +16,7 @@ public final class CacheNames {
     public static final String TRANSACTION_CACHE = "transactionCache";
     public static final String RETURNS_CACHE = "returnsCache";
     public static final String PORTFOLIO_HISTORY_CACHE = "portfolioHistoryCache";
+    public static final String SUMMARY_CACHE = "portfolioSummaryCache";
 
     // Prevent instantiation
     private CacheNames() {

--- a/src/main/java/com/app/folioman/config/redis/RedisConfig.java
+++ b/src/main/java/com/app/folioman/config/redis/RedisConfig.java
@@ -87,6 +87,7 @@ class RedisConfig implements CachingConfigurer {
                 CacheNames.USER_PROFILE_CACHE, cacheConfiguration.entryTtl(Duration.ofMinutes(5)));
         initialCacheConfigurations.put(
                 CacheNames.PORTFOLIO_HISTORY_CACHE, cacheConfiguration.entryTtl(Duration.ofHours(1)));
+        initialCacheConfigurations.put(CacheNames.SUMMARY_CACHE, cacheConfiguration.entryTtl(Duration.ofMinutes(15)));
 
         // Create the custom cache manager with our circuit breaker and default TTL
         return new CustomRedisCacheManager(

--- a/src/main/java/com/app/folioman/mfschemes/MFNavService.java
+++ b/src/main/java/com/app/folioman/mfschemes/MFNavService.java
@@ -39,4 +39,13 @@ public interface MFNavService {
      */
     Map<Long, Map<LocalDate, MFSchemeNavProjection>> getNavsForSchemesAndDates(
             Set<Long> schemeCodes, LocalDate startDate, LocalDate endDate);
+
+    /**
+     * Retrieves the last two NAVs for a given set of AMFI codes.
+     * Batched to avoid N+1 lookups.
+     *
+     * @param amfiCodes Set of AMFI codes
+     * @return Map of AMFI code to a list of the latest two NAV projections
+     */
+    Map<Long, List<MFSchemeNavProjection>> getLastTwoNavsForSchemes(Set<Long> amfiCodes);
 }

--- a/src/main/java/com/app/folioman/mfschemes/domain/MFNavServiceImpl.java
+++ b/src/main/java/com/app/folioman/mfschemes/domain/MFNavServiceImpl.java
@@ -235,6 +235,18 @@ class MFNavServiceImpl implements MFNavService {
                         Collectors.toMap(MFSchemeNavProjection::navDate, Function.identity())));
     }
 
+    @Override
+    public Map<Long, List<MFSchemeNavProjection>> getLastTwoNavsForSchemes(Set<Long> amfiCodes) {
+        if (amfiCodes == null || amfiCodes.isEmpty()) {
+            return Map.of();
+        }
+
+        LOGGER.info("Fetching last 2 NAVs for amfiCodes: {}", amfiCodes);
+        return mfSchemeNavRepository.findLatest2NavsByAmfiCodes(amfiCodes).stream()
+                .map(p -> new MFSchemeNavProjection(p.getNav(), p.getNavDate(), p.getAmfiCode()))
+                .collect(Collectors.groupingBy(MFSchemeNavProjection::amfiCode));
+    }
+
     private Map<String, String> getAmfiCodeIsinMap(String allNAVs) {
         Map<String, String> amfiCodeIsinMap = new HashMap<>();
         for (String row : allNAVs.split("\n")) {

--- a/src/main/java/com/app/folioman/mfschemes/domain/MfSchemeNavRepository.java
+++ b/src/main/java/com/app/folioman/mfschemes/domain/MfSchemeNavRepository.java
@@ -50,4 +50,24 @@ interface MfSchemeNavRepository extends JpaRepository<MFSchemeNavEntity, Long> {
     @Query(
             "SELECT new com.app.folioman.mfschemes.domain.models.projection.NavDateValueProjection(n.nav, n.navDate) FROM MFSchemeNavEntity n WHERE n.mfFundSchemeEntity.id = :schemeId")
     List<NavDateValueProjection> findAllNavDateValuesBySchemeId(@Param("schemeId") Long schemeId);
+
+    @Query(value = """
+            SELECT nav, nav_date as navDate, amfi_code as amfiCode FROM (
+                SELECT msn.nav, msn.nav_date, mfs.amfi_code,
+                       ROW_NUMBER() OVER (PARTITION BY mfs.amfi_code ORDER BY msn.nav_date DESC, msn.id DESC) as rn
+                FROM mfschemes.mf_scheme_nav msn
+                JOIN mfschemes.mf_fund_scheme mfs ON msn.mf_scheme_id = mfs.id
+                WHERE mfs.amfi_code IN :amfiCodes
+            ) sub
+            WHERE sub.rn <= 2
+            """, nativeQuery = true)
+    List<AmfiNavProjection> findLatest2NavsByAmfiCodes(@Param("amfiCodes") Set<Long> amfiCodes);
+
+    interface AmfiNavProjection {
+        java.math.BigDecimal getNav();
+
+        LocalDate getNavDate();
+
+        Long getAmfiCode();
+    }
 }

--- a/src/main/java/com/app/folioman/mfschemes/domain/MfSchemeNavRepository.java
+++ b/src/main/java/com/app/folioman/mfschemes/domain/MfSchemeNavRepository.java
@@ -60,6 +60,7 @@ interface MfSchemeNavRepository extends JpaRepository<MFSchemeNavEntity, Long> {
                 WHERE mfs.amfi_code IN :amfiCodes
             ) sub
             WHERE sub.rn <= 2
+            ORDER BY sub.amfi_code, sub.rn ASC
             """, nativeQuery = true)
     List<AmfiNavProjection> findLatest2NavsByAmfiCodes(@Param("amfiCodes") Set<Long> amfiCodes);
 

--- a/src/main/java/com/app/folioman/mfschemes/domain/MfSchemeServiceImpl.java
+++ b/src/main/java/com/app/folioman/mfschemes/domain/MfSchemeServiceImpl.java
@@ -134,10 +134,30 @@ class MfSchemeServiceImpl implements MfSchemeService {
             }
 
             @Override
+            public @org.jspecify.annotations.Nullable String getPlan() {
+                return entity.getPlan();
+            }
+
+            @Override
+            public @org.jspecify.annotations.Nullable String getRta() {
+                return entity.getRta();
+            }
+
+            @Override
             public com.app.folioman.mfschemes.rest.dtos.@org.jspecify.annotations.Nullable MFSchemeTypeProjection
                     getMfSchemeTypeEntity() {
                 if (entity.getMfSchemeTypeEntity() != null) {
-                    return () -> entity.getMfSchemeTypeEntity().getCategory();
+                    return new com.app.folioman.mfschemes.rest.dtos.MFSchemeTypeProjection() {
+                        @Override
+                        public @org.jspecify.annotations.Nullable String getCategory() {
+                            return entity.getMfSchemeTypeEntity().getCategory();
+                        }
+
+                        @Override
+                        public @org.jspecify.annotations.Nullable String getSubCategory() {
+                            return entity.getMfSchemeTypeEntity().getSubCategory();
+                        }
+                    };
                 }
                 return null;
             }

--- a/src/main/java/com/app/folioman/mfschemes/rest/dtos/MFSchemeProjection.java
+++ b/src/main/java/com/app/folioman/mfschemes/rest/dtos/MFSchemeProjection.java
@@ -12,5 +12,11 @@ public interface MFSchemeProjection {
     String getIsin();
 
     @Nullable
+    String getPlan();
+
+    @Nullable
+    String getRta();
+
+    @Nullable
     MFSchemeTypeProjection getMfSchemeTypeEntity();
 }

--- a/src/main/java/com/app/folioman/mfschemes/rest/dtos/MFSchemeTypeProjection.java
+++ b/src/main/java/com/app/folioman/mfschemes/rest/dtos/MFSchemeTypeProjection.java
@@ -5,4 +5,7 @@ import org.jspecify.annotations.Nullable;
 public interface MFSchemeTypeProjection {
     @Nullable
     String getCategory();
+
+    @Nullable
+    String getSubCategory();
 }

--- a/src/main/java/com/app/folioman/portfolio/PortfolioAPI.java
+++ b/src/main/java/com/app/folioman/portfolio/PortfolioAPI.java
@@ -31,6 +31,9 @@ public interface PortfolioAPI {
 
     Optional<PortfolioHistoryDTO> getPortfolioHistory(Long casId, String userEmail, LocalDate from, LocalDate to);
 
+    Optional<com.app.folioman.portfolio.rest.dtos.PortfolioSummaryDTO> getPortfolioSummary(
+            Long casId, String userEmail);
+
     CasDTO convertPdfCasToJson(MultipartFile pdfFile, String password) throws IOException;
 
     List<PortfolioSummaryProjection> getPortfolioSummariesByEmail(String email);

--- a/src/main/java/com/app/folioman/portfolio/domain/FolioSchemeRepository.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/FolioSchemeRepository.java
@@ -1,5 +1,6 @@
 package com.app.folioman.portfolio.domain;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,8 @@ interface FolioSchemeRepository extends JpaRepository<FolioSchemeEntity, Long> {
      * @return the FolioSchemeEntity if found
      */
     Optional<FolioSchemeEntity> findByUserSchemeDetails_Id(Long userSchemeDetailId);
+
+    List<FolioSchemeEntity> findByUserSchemeDetails_IdIn(Collection<Long> schemeDetailIds);
 
     List<FolioSchemeEntity> findByUserFolioDetails_Id(Long id);
 }

--- a/src/main/java/com/app/folioman/portfolio/domain/PortfolioAPIImpl.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/PortfolioAPIImpl.java
@@ -38,6 +38,7 @@ public class PortfolioAPIImpl implements PortfolioAPI {
     private final UserCASDetailsRepository userCASDetailsRepository;
     private final UserPortfolioValueRepository userPortfolioValueRepository;
     private final CapitalGainsHarvestingService capitalGainsHarvestingService;
+    private final PortfolioSummaryService portfolioSummaryService;
 
     PortfolioAPIImpl(
             UserTransactionDetailsService userTransactionDetailsService,
@@ -45,13 +46,15 @@ public class PortfolioAPIImpl implements PortfolioAPI {
             PdfProcessingService pdfProcessingService,
             UserCASDetailsRepository userCASDetailsRepository,
             UserPortfolioValueRepository userPortfolioValueRepository,
-            CapitalGainsHarvestingService capitalGainsHarvestingService) {
+            CapitalGainsHarvestingService capitalGainsHarvestingService,
+            PortfolioSummaryService portfolioSummaryService) {
         this.userTransactionDetailsService = userTransactionDetailsService;
         this.userDetailService = userDetailService;
         this.pdfProcessingService = pdfProcessingService;
         this.userCASDetailsRepository = userCASDetailsRepository;
         this.userPortfolioValueRepository = userPortfolioValueRepository;
         this.capitalGainsHarvestingService = capitalGainsHarvestingService;
+        this.portfolioSummaryService = portfolioSummaryService;
     }
 
     public Optional<InvestmentReturnsDTO> getInvestmentReturnsByPan(String pan) {
@@ -148,6 +151,13 @@ public class PortfolioAPIImpl implements PortfolioAPI {
 
                     return new PortfolioHistoryDTO(invested, value);
                 });
+    }
+
+    @Override
+    @Cacheable(cacheNames = CacheNames.SUMMARY_CACHE, key = "'summary_' + #casId + '_' + #userEmail")
+    public Optional<com.app.folioman.portfolio.rest.dtos.PortfolioSummaryDTO> getPortfolioSummary(
+            Long casId, String userEmail) {
+        return portfolioSummaryService.getPortfolioSummary(casId, userEmail);
     }
 
     public CapitalGainsHarvestingResponseDTO getCapitalGainsHarvesting(

--- a/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
@@ -76,23 +76,35 @@ public class PortfolioSummaryService {
 
         Map<Long, List<MFSchemeNavProjection>> navMap = mfNavService.getLastTwoNavsForSchemes(amfiCodes);
 
+        List<Long> schemeDetailIds = cas.getFolios().stream()
+                .flatMap(f -> f.getSchemes().stream())
+                .map(UserSchemeDetailsEntity::getId)
+                .toList();
+
+        Map<Long, SchemeValueEntity> latestSchemeValues = schemeDetailIds.isEmpty()
+                ? Map.of()
+                : schemeValueRepository.findLatestValuesBySchemeDetailsIds(schemeDetailIds).stream()
+                        .collect(Collectors.toMap(
+                                sv -> sv.getUserSchemeDetails().getId(), Function.identity(), (a, b) -> a));
+
+        Map<Long, FolioSchemeEntity> folioSchemes = schemeDetailIds.isEmpty()
+                ? Map.of()
+                : folioSchemeRepository.findByUserSchemeDetails_IdIn(schemeDetailIds).stream()
+                        .collect(Collectors.toMap(
+                                fs -> fs.getUserSchemeDetails().getId(), Function.identity(), (a, b) -> a));
+
         for (UserFolioDetailsEntity folio : cas.getFolios()) {
             for (UserSchemeDetailsEntity schemeDetails : folio.getSchemes()) {
-                Optional<SchemeValueEntity> schemeValueOpt =
-                        schemeValueRepository.findFirstByUserSchemeDetailsEntity_IdOrderByDateDesc(
-                                schemeDetails.getId());
+                SchemeValueEntity schemeValue = latestSchemeValues.get(schemeDetails.getId());
 
-                if (schemeValueOpt.isEmpty()) continue;
+                if (schemeValue == null) continue;
 
-                SchemeValueEntity schemeValue = schemeValueOpt.get();
                 if (schemeValue.getBalance() == null || schemeValue.getBalance().compareTo(BigDecimal.ZERO) == 0) {
                     continue; // Skip zero balance
                 }
 
-                BigDecimal xirr = folioSchemeRepository
-                        .findByUserSchemeDetails_Id(schemeDetails.getId())
-                        .map(FolioSchemeEntity::getXirr)
-                        .orElse(null);
+                FolioSchemeEntity fs = folioSchemes.get(schemeDetails.getId());
+                BigDecimal xirr = fs != null ? fs.getXirr() : null;
 
                 allFolioData.add(new FolioData(folio.getFolio(), schemeDetails, schemeValue, xirr));
             }
@@ -212,19 +224,6 @@ public class PortfolioSummaryService {
             portTotalChangeD = portTotalChangeD.add(schemeChangeD);
         }
 
-        BigDecimal portChangePctA = BigDecimal.ZERO;
-        if (portTotalInvested.compareTo(BigDecimal.ZERO) > 0) {
-            portChangePctA =
-                    portTotalChangeA.multiply(new BigDecimal("100")).divide(portTotalInvested, 2, RoundingMode.HALF_UP);
-        }
-
-        BigDecimal portChangePctD = BigDecimal.ZERO;
-        BigDecimal portPrevValue = portTotalValue.subtract(portTotalChangeD);
-        if (portPrevValue.compareTo(BigDecimal.ZERO) > 0) {
-            portChangePctD =
-                    portTotalChangeD.multiply(new BigDecimal("100")).divide(portPrevValue, 2, RoundingMode.HALF_UP);
-        }
-
         Optional<PortfolioValueDateProjection> portValueOpt =
                 userPortfolioValueRepository.getLatestPortfolioValueByCasId(casId);
 
@@ -239,6 +238,21 @@ public class PortfolioSummaryService {
             if (p.getValue() != null) finalPortValue = p.getValue();
             if (p.getDate() != null) finalDate = p.getDate();
             if (p.getXirr() != null) overallXirr = p.getXirr();
+        }
+
+        portTotalChangeA = finalPortValue.subtract(finalPortInvested);
+
+        BigDecimal portChangePctA = BigDecimal.ZERO;
+        if (finalPortInvested.compareTo(BigDecimal.ZERO) > 0) {
+            portChangePctA =
+                    portTotalChangeA.multiply(new BigDecimal("100")).divide(finalPortInvested, 2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal portChangePctD = BigDecimal.ZERO;
+        BigDecimal portPrevValue = finalPortValue.subtract(portTotalChangeD);
+        if (portPrevValue.compareTo(BigDecimal.ZERO) > 0) {
+            portChangePctD =
+                    portTotalChangeD.multiply(new BigDecimal("100")).divide(portPrevValue, 2, RoundingMode.HALF_UP);
         }
 
         PortfolioSummaryDTO responseDTO = new PortfolioSummaryDTO(

--- a/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -197,9 +198,7 @@ public class PortfolioSummaryService {
                 schemeChangePctD =
                         schemeChangeD.multiply(new BigDecimal("100")).divide(prevValue, 2, RoundingMode.HALF_UP);
             }
-
-            BigDecimal schemeXirr = folioDataList.get(0).xirr();
-
+            BigDecimal schemeXirr = getXirr(folioDataList);
             schemeSummaries.add(new SchemeSummaryDTO(
                     isin,
                     name,
@@ -238,6 +237,7 @@ public class PortfolioSummaryService {
             if (p.getValue() != null) finalPortValue = p.getValue();
             if (p.getDate() != null) finalDate = p.getDate();
             if (p.getXirr() != null) overallXirr = p.getXirr();
+            if (p.getLiveXirr() != null) currentXirr = p.getLiveXirr();
         }
 
         portTotalChangeA = finalPortValue.subtract(finalPortInvested);
@@ -269,9 +269,27 @@ public class PortfolioSummaryService {
         return Optional.of(responseDTO);
     }
 
+    private @Nullable BigDecimal getXirr(List<FolioData> folioDataList) {
+        BigDecimal totalXirrWeight = BigDecimal.ZERO;
+        BigDecimal totalWeightedXirr = BigDecimal.ZERO;
+        for (FolioData fd : folioDataList) {
+            if (fd.xirr() != null
+                    && fd.schemeValue().getInvested() != null
+                    && fd.schemeValue().getInvested().compareTo(BigDecimal.ZERO) > 0) {
+                totalXirrWeight = totalXirrWeight.add(fd.schemeValue().getInvested());
+                totalWeightedXirr = totalWeightedXirr.add(
+                        fd.xirr().multiply(fd.schemeValue().getInvested()));
+            }
+        }
+        BigDecimal schemeXirr = totalXirrWeight.compareTo(BigDecimal.ZERO) > 0
+                ? totalWeightedXirr.divide(totalXirrWeight, 2, RoundingMode.HALF_UP)
+                : null;
+        return schemeXirr;
+    }
+
     private record FolioData(
             String folioNumber,
             UserSchemeDetailsEntity schemeDetails,
             SchemeValueEntity schemeValue,
-            @org.jspecify.annotations.Nullable BigDecimal xirr) {}
+            @Nullable BigDecimal xirr) {}
 }

--- a/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
@@ -36,7 +36,7 @@ public class PortfolioSummaryService {
     private final MfSchemeService mfSchemeService;
     private final MFNavService mfNavService;
 
-    public PortfolioSummaryService(
+    PortfolioSummaryService(
             UserCASDetailsRepository userCASDetailsRepository,
             SchemeValueRepository schemeValueRepository,
             FolioSchemeRepository folioSchemeRepository,

--- a/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/PortfolioSummaryService.java
@@ -1,0 +1,263 @@
+package com.app.folioman.portfolio.domain;
+
+import com.app.folioman.mfschemes.MFNavService;
+import com.app.folioman.mfschemes.MfSchemeService;
+import com.app.folioman.mfschemes.rest.dtos.MFSchemeNavProjection;
+import com.app.folioman.mfschemes.rest.dtos.MFSchemeProjection;
+import com.app.folioman.portfolio.domain.models.projection.PortfolioValueDateProjection;
+import com.app.folioman.portfolio.rest.dtos.CategoryDTO;
+import com.app.folioman.portfolio.rest.dtos.ChangeDTO;
+import com.app.folioman.portfolio.rest.dtos.FolioSummaryDTO;
+import com.app.folioman.portfolio.rest.dtos.PortfolioSummaryDTO;
+import com.app.folioman.portfolio.rest.dtos.SchemeSummaryDTO;
+import com.app.folioman.portfolio.rest.dtos.XirrDTO;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class PortfolioSummaryService {
+
+    private final UserCASDetailsRepository userCASDetailsRepository;
+    private final SchemeValueRepository schemeValueRepository;
+    private final FolioSchemeRepository folioSchemeRepository;
+    private final UserPortfolioValueRepository userPortfolioValueRepository;
+    private final MfSchemeService mfSchemeService;
+    private final MFNavService mfNavService;
+
+    public PortfolioSummaryService(
+            UserCASDetailsRepository userCASDetailsRepository,
+            SchemeValueRepository schemeValueRepository,
+            FolioSchemeRepository folioSchemeRepository,
+            UserPortfolioValueRepository userPortfolioValueRepository,
+            MfSchemeService mfSchemeService,
+            MFNavService mfNavService) {
+        this.userCASDetailsRepository = userCASDetailsRepository;
+        this.schemeValueRepository = schemeValueRepository;
+        this.folioSchemeRepository = folioSchemeRepository;
+        this.userPortfolioValueRepository = userPortfolioValueRepository;
+        this.mfSchemeService = mfSchemeService;
+        this.mfNavService = mfNavService;
+    }
+
+    public Optional<PortfolioSummaryDTO> getPortfolioSummary(Long casId, String userEmail) {
+        Optional<UserCasDetailsEntity> casOpt = userCASDetailsRepository.findUserCasDetailsEntityById(casId);
+
+        if (casOpt.isEmpty()
+                || casOpt.get().getInvestorInfoEntity() == null
+                || !userEmail.equals(casOpt.get().getInvestorInfoEntity().getEmail())) {
+            return Optional.empty();
+        }
+
+        UserCasDetailsEntity cas = casOpt.get();
+
+        List<FolioData> allFolioData = new ArrayList<>();
+        Set<Long> amfiCodes = cas.getFolios().stream()
+                .flatMap(f -> f.getSchemes().stream())
+                .map(UserSchemeDetailsEntity::getAmfi)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        // Batch fetch metadata and navs
+        Map<Long, MFSchemeProjection> schemeMetadata =
+                mfSchemeService.findByAmfiCodeIn(new ArrayList<>(amfiCodes)).stream()
+                        .collect(Collectors.toMap(MFSchemeProjection::getAmfiCode, Function.identity(), (a, b) -> a));
+
+        Map<Long, List<MFSchemeNavProjection>> navMap = mfNavService.getLastTwoNavsForSchemes(amfiCodes);
+
+        for (UserFolioDetailsEntity folio : cas.getFolios()) {
+            for (UserSchemeDetailsEntity schemeDetails : folio.getSchemes()) {
+                Optional<SchemeValueEntity> schemeValueOpt =
+                        schemeValueRepository.findFirstByUserSchemeDetailsEntity_IdOrderByDateDesc(
+                                schemeDetails.getId());
+
+                if (schemeValueOpt.isEmpty()) continue;
+
+                SchemeValueEntity schemeValue = schemeValueOpt.get();
+                if (schemeValue.getBalance() == null || schemeValue.getBalance().compareTo(BigDecimal.ZERO) == 0) {
+                    continue; // Skip zero balance
+                }
+
+                BigDecimal xirr = folioSchemeRepository
+                        .findByUserSchemeDetails_Id(schemeDetails.getId())
+                        .map(FolioSchemeEntity::getXirr)
+                        .orElse(null);
+
+                allFolioData.add(new FolioData(folio.getFolio(), schemeDetails, schemeValue, xirr));
+            }
+        }
+
+        Map<Long, List<FolioData>> groupedByAmfi = allFolioData.stream()
+                .filter(fd -> fd.schemeDetails().getAmfi() != null)
+                .collect(Collectors.groupingBy(fd -> fd.schemeDetails().getAmfi()));
+
+        List<SchemeSummaryDTO> schemeSummaries = new ArrayList<>();
+        BigDecimal portTotalInvested = BigDecimal.ZERO;
+        BigDecimal portTotalValue = BigDecimal.ZERO;
+        BigDecimal portTotalChangeA = BigDecimal.ZERO;
+        BigDecimal portTotalChangeD = BigDecimal.ZERO;
+
+        for (Map.Entry<Long, List<FolioData>> entry : groupedByAmfi.entrySet()) {
+            Long amfiCode = entry.getKey();
+            List<FolioData> folioDataList = entry.getValue();
+
+            BigDecimal schemeInvested = BigDecimal.ZERO;
+            BigDecimal schemeUnits = BigDecimal.ZERO;
+            BigDecimal schemeValue = BigDecimal.ZERO;
+            BigDecimal schemeAvgNav = null;
+
+            List<FolioSummaryDTO> folioSummaries = new ArrayList<>();
+
+            for (FolioData fd : folioDataList) {
+                BigDecimal invested = fd.schemeValue().getInvested() != null
+                        ? fd.schemeValue().getInvested()
+                        : BigDecimal.ZERO;
+                BigDecimal units =
+                        fd.schemeValue().getBalance() != null ? fd.schemeValue().getBalance() : BigDecimal.ZERO;
+                BigDecimal value =
+                        fd.schemeValue().getValue() != null ? fd.schemeValue().getValue() : BigDecimal.ZERO;
+
+                schemeInvested = schemeInvested.add(invested);
+                schemeUnits = schemeUnits.add(units);
+                schemeValue = schemeValue.add(value);
+
+                Double avgNav = fd.schemeValue().getAvgNav() != null
+                        ? fd.schemeValue().getAvgNav().doubleValue()
+                        : null;
+
+                folioSummaries.add(new FolioSummaryDTO(
+                        fd.folioNumber(), invested.doubleValue(), units.doubleValue(), value.doubleValue(), avgNav));
+            }
+
+            if (schemeUnits.compareTo(BigDecimal.ZERO) > 0) {
+                schemeAvgNav = schemeInvested.divide(schemeUnits, 4, RoundingMode.HALF_UP);
+            }
+
+            MFSchemeProjection meta = schemeMetadata.get(amfiCode);
+            String mainCat = meta != null
+                            && meta.getMfSchemeTypeEntity() != null
+                            && meta.getMfSchemeTypeEntity().getCategory() != null
+                    ? meta.getMfSchemeTypeEntity().getCategory()
+                    : "Unknown";
+            String subCat = meta != null
+                            && meta.getMfSchemeTypeEntity() != null
+                            && meta.getMfSchemeTypeEntity().getSubCategory() != null
+                    ? meta.getMfSchemeTypeEntity().getSubCategory()
+                    : "Unknown";
+            String rta = meta != null && meta.getRta() != null ? meta.getRta() : "Unknown";
+            String plan = meta != null && meta.getPlan() != null ? meta.getPlan() : "Unknown";
+            String metaIsin = meta != null ? meta.getIsin() : null;
+            String isin = metaIsin != null
+                    ? metaIsin
+                    : (folioDataList.get(0).schemeDetails().getIsin() != null
+                            ? folioDataList.get(0).schemeDetails().getIsin()
+                            : amfiCode.toString());
+            String name = folioDataList.get(0).schemeDetails().getScheme();
+
+            List<MFSchemeNavProjection> navs = navMap.getOrDefault(amfiCode, List.of());
+            BigDecimal nav0 = !navs.isEmpty() ? navs.get(0).nav() : BigDecimal.ZERO;
+            BigDecimal nav1 = navs.size() > 1 ? navs.get(1).nav() : nav0;
+            LocalDate navDate = !navs.isEmpty() ? navs.get(0).navDate() : LocalDate.now();
+
+            BigDecimal schemeChangeA = schemeValue.subtract(schemeInvested);
+            BigDecimal schemeChangeD = schemeValue.subtract(schemeUnits.multiply(nav1));
+
+            BigDecimal schemeChangePctA = BigDecimal.ZERO;
+            if (schemeInvested.compareTo(BigDecimal.ZERO) > 0) {
+                schemeChangePctA =
+                        schemeChangeA.multiply(new BigDecimal("100")).divide(schemeInvested, 2, RoundingMode.HALF_UP);
+            }
+
+            BigDecimal schemeChangePctD = BigDecimal.ZERO;
+            BigDecimal prevValue = schemeUnits.multiply(nav1);
+            if (prevValue.compareTo(BigDecimal.ZERO) > 0) {
+                schemeChangePctD =
+                        schemeChangeD.multiply(new BigDecimal("100")).divide(prevValue, 2, RoundingMode.HALF_UP);
+            }
+
+            BigDecimal schemeXirr = folioDataList.get(0).xirr();
+
+            schemeSummaries.add(new SchemeSummaryDTO(
+                    isin,
+                    name,
+                    schemeXirr != null ? schemeXirr.doubleValue() : null,
+                    new CategoryDTO(mainCat, subCat),
+                    rta,
+                    plan,
+                    nav0.doubleValue(),
+                    nav1.doubleValue(),
+                    navDate,
+                    schemeInvested.doubleValue(),
+                    schemeUnits.doubleValue(),
+                    schemeValue.doubleValue(),
+                    schemeAvgNav != null ? schemeAvgNav.doubleValue() : null,
+                    new ChangeDTO(schemeChangeD.doubleValue(), schemeChangeA.doubleValue()),
+                    new ChangeDTO(schemeChangePctD.doubleValue(), schemeChangePctA.doubleValue()),
+                    folioSummaries));
+
+            portTotalInvested = portTotalInvested.add(schemeInvested);
+            portTotalValue = portTotalValue.add(schemeValue);
+            portTotalChangeA = portTotalChangeA.add(schemeChangeA);
+            portTotalChangeD = portTotalChangeD.add(schemeChangeD);
+        }
+
+        BigDecimal portChangePctA = BigDecimal.ZERO;
+        if (portTotalInvested.compareTo(BigDecimal.ZERO) > 0) {
+            portChangePctA =
+                    portTotalChangeA.multiply(new BigDecimal("100")).divide(portTotalInvested, 2, RoundingMode.HALF_UP);
+        }
+
+        BigDecimal portChangePctD = BigDecimal.ZERO;
+        BigDecimal portPrevValue = portTotalValue.subtract(portTotalChangeD);
+        if (portPrevValue.compareTo(BigDecimal.ZERO) > 0) {
+            portChangePctD =
+                    portTotalChangeD.multiply(new BigDecimal("100")).divide(portPrevValue, 2, RoundingMode.HALF_UP);
+        }
+
+        Optional<PortfolioValueDateProjection> portValueOpt =
+                userPortfolioValueRepository.getLatestPortfolioValueByCasId(casId);
+
+        BigDecimal finalPortValue = portTotalValue;
+        BigDecimal finalPortInvested = portTotalInvested;
+        LocalDate finalDate = LocalDate.now();
+        BigDecimal currentXirr = null;
+        BigDecimal overallXirr = null;
+
+        if (portValueOpt.isPresent()) {
+            PortfolioValueDateProjection p = portValueOpt.get();
+            if (p.getValue() != null) finalPortValue = p.getValue();
+            if (p.getDate() != null) finalDate = p.getDate();
+            if (p.getXirr() != null) overallXirr = p.getXirr();
+        }
+
+        PortfolioSummaryDTO responseDTO = new PortfolioSummaryDTO(
+                finalPortInvested.doubleValue(),
+                finalPortValue.doubleValue(),
+                new XirrDTO(
+                        currentXirr != null ? currentXirr.doubleValue() : null,
+                        overallXirr != null ? overallXirr.doubleValue() : null),
+                new ChangeDTO(portTotalChangeD.doubleValue(), portTotalChangeA.doubleValue()),
+                new ChangeDTO(portChangePctD.doubleValue(), portChangePctA.doubleValue()),
+                finalDate,
+                schemeSummaries);
+
+        return Optional.of(responseDTO);
+    }
+
+    private record FolioData(
+            String folioNumber,
+            UserSchemeDetailsEntity schemeDetails,
+            SchemeValueEntity schemeValue,
+            @org.jspecify.annotations.Nullable BigDecimal xirr) {}
+}

--- a/src/main/java/com/app/folioman/portfolio/domain/SchemeValueEntity.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/SchemeValueEntity.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.SequenceGenerator;
@@ -14,7 +15,10 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Entity
-@Table(name = "scheme_value", schema = "portfolio")
+@Table(
+        name = "scheme_value",
+        schema = "portfolio",
+        indexes = {@Index(name = "idx_scheme_value_usd_id_date", columnList = "user_scheme_detail_id, date")})
 @SuppressWarnings("NullAway.Init")
 class SchemeValueEntity extends BaseEntity {
 

--- a/src/main/java/com/app/folioman/portfolio/domain/SchemeValueRepository.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/SchemeValueRepository.java
@@ -11,6 +11,8 @@ interface SchemeValueRepository extends JpaRepository<@NonNull SchemeValueEntity
 
     Optional<SchemeValueEntity> findFirstByUserSchemeDetailsEntity_UserFolioDetails_IdOrderByDateDesc(Long id);
 
+    Optional<SchemeValueEntity> findFirstByUserSchemeDetailsEntity_IdOrderByDateDesc(Long id);
+
     Optional<SchemeValueEntity> findFirstByUserSchemeDetailsEntity_IdAndDateBeforeOrderByDateDesc(
             Long id, LocalDate schemeFromDate);
 }

--- a/src/main/java/com/app/folioman/portfolio/domain/SchemeValueRepository.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/SchemeValueRepository.java
@@ -1,9 +1,13 @@
 package com.app.folioman.portfolio.domain;
 
+import io.lettuce.core.dynamic.annotation.Param;
 import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.jspecify.annotations.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,8 +15,13 @@ interface SchemeValueRepository extends JpaRepository<@NonNull SchemeValueEntity
 
     Optional<SchemeValueEntity> findFirstByUserSchemeDetailsEntity_UserFolioDetails_IdOrderByDateDesc(Long id);
 
-    Optional<SchemeValueEntity> findFirstByUserSchemeDetailsEntity_IdOrderByDateDesc(Long id);
-
     Optional<SchemeValueEntity> findFirstByUserSchemeDetailsEntity_IdAndDateBeforeOrderByDateDesc(
             Long id, LocalDate schemeFromDate);
+
+    @Query("""
+            SELECT sv FROM SchemeValueEntity sv
+            WHERE sv.userSchemeDetailsEntity.id IN :schemeIds
+              AND sv.date = (SELECT MAX(sv2.date) FROM SchemeValueEntity sv2 WHERE sv2.userSchemeDetailsEntity.id = sv.userSchemeDetailsEntity.id)
+            """)
+    List<SchemeValueEntity> findLatestValuesBySchemeDetailsIds(@Param("schemeIds") Collection<Long> schemeIds);
 }

--- a/src/main/java/com/app/folioman/portfolio/domain/UserPortfolioValueRepository.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/UserPortfolioValueRepository.java
@@ -28,7 +28,7 @@ interface UserPortfolioValueRepository extends JpaRepository<UserPortfolioValueE
     Optional<UserPortfolioValueProjection> getLatestPortfolioValueByPan(@Param("pan") String pan);
 
     @NativeQuery("""
-            SELECT upv.value as value, upv.date as date, upv.xirr as xirr
+            SELECT upv.value as value, upv.date as date, upv.xirr as xirr, upv.live_xirr as liveXirr
             FROM portfolio.user_portfolio_value upv
             WHERE upv.user_cas_details_id = :casId
             ORDER BY upv.date DESC, upv.id DESC

--- a/src/main/java/com/app/folioman/portfolio/domain/models/projection/PortfolioValueDateProjection.java
+++ b/src/main/java/com/app/folioman/portfolio/domain/models/projection/PortfolioValueDateProjection.java
@@ -11,4 +11,7 @@ public interface PortfolioValueDateProjection {
 
     @Nullable
     BigDecimal getXirr();
+
+    @Nullable
+    BigDecimal getLiveXirr();
 }

--- a/src/main/java/com/app/folioman/portfolio/rest/controllers/ImportMutualFundController.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/controllers/ImportMutualFundController.java
@@ -51,8 +51,10 @@ public class ImportMutualFundController {
                                 "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()"),
                 @CacheEvict(
                         cacheNames = CacheNames.SUMMARY_CACHE,
+                        condition =
+                                "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
                         key =
-                                "'summary_' + #result.userCASDetailsId + '_' + T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
+                                "'summary_' + #result.userCASDetailsId() + '_' + T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
             })
     public UploadFileResponse upload(@RequestPart("file") MultipartFile multipartFile) throws IOException {
         LOGGER.info("Received file :{} for processing", multipartFile.getOriginalFilename());
@@ -70,8 +72,10 @@ public class ImportMutualFundController {
                                 "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()"),
                 @CacheEvict(
                         cacheNames = CacheNames.SUMMARY_CACHE,
+                        condition =
+                                "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
                         key =
-                                "'summary_' + #result.userCASDetailsId + '_' + T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
+                                "'summary_' + #result.userCASDetailsId() + '_' + T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
             })
     public UploadFileResponse uploadPasswordProtectedCasPdf(
             @RequestPart("file") MultipartFile pdfFile, @RequestPart("password") String password) throws IOException {

--- a/src/main/java/com/app/folioman/portfolio/rest/controllers/ImportMutualFundController.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/controllers/ImportMutualFundController.java
@@ -14,6 +14,7 @@ import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.MediaType;
 import org.springframework.validation.annotation.Validated;
@@ -40,24 +41,32 @@ public class ImportMutualFundController {
     }
 
     @PostMapping(value = "/api/upload-handler", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @CacheEvict(
-            cacheNames = CacheNames.USER_PROFILE_CACHE,
-            condition =
-                    "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
-            key =
-                    "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
+    @Caching(
+            evict = {
+                @CacheEvict(
+                        cacheNames = CacheNames.USER_PROFILE_CACHE,
+                        condition =
+                                "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
+                        key =
+                                "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()"),
+                @CacheEvict(cacheNames = CacheNames.SUMMARY_CACHE, allEntries = true)
+            })
     public UploadFileResponse upload(@RequestPart("file") MultipartFile multipartFile) throws IOException {
         LOGGER.info("Received file :{} for processing", multipartFile.getOriginalFilename());
         return portfolioAPI.upload(multipartFile);
     }
 
     @PostMapping(value = "/api/upload-pdf-cas", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    @CacheEvict(
-            cacheNames = CacheNames.USER_PROFILE_CACHE,
-            condition =
-                    "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
-            key =
-                    "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
+    @Caching(
+            evict = {
+                @CacheEvict(
+                        cacheNames = CacheNames.USER_PROFILE_CACHE,
+                        condition =
+                                "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
+                        key =
+                                "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()"),
+                @CacheEvict(cacheNames = CacheNames.SUMMARY_CACHE, allEntries = true)
+            })
     public UploadFileResponse uploadPasswordProtectedCasPdf(
             @RequestPart("file") MultipartFile pdfFile, @RequestPart("password") String password) throws IOException {
         LOGGER.info("Received password-protected PDF file: {} for processing", pdfFile.getOriginalFilename());

--- a/src/main/java/com/app/folioman/portfolio/rest/controllers/ImportMutualFundController.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/controllers/ImportMutualFundController.java
@@ -49,7 +49,10 @@ public class ImportMutualFundController {
                                 "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
                         key =
                                 "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()"),
-                @CacheEvict(cacheNames = CacheNames.SUMMARY_CACHE, allEntries = true)
+                @CacheEvict(
+                        cacheNames = CacheNames.SUMMARY_CACHE,
+                        key =
+                                "'summary_' + #result.userCASDetailsId + '_' + T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
             })
     public UploadFileResponse upload(@RequestPart("file") MultipartFile multipartFile) throws IOException {
         LOGGER.info("Received file :{} for processing", multipartFile.getOriginalFilename());
@@ -65,7 +68,10 @@ public class ImportMutualFundController {
                                 "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication() != null",
                         key =
                                 "T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()"),
-                @CacheEvict(cacheNames = CacheNames.SUMMARY_CACHE, allEntries = true)
+                @CacheEvict(
+                        cacheNames = CacheNames.SUMMARY_CACHE,
+                        key =
+                                "'summary_' + #result.userCASDetailsId + '_' + T(org.springframework.security.core.context.SecurityContextHolder).getContext().getAuthentication().getName()")
             })
     public UploadFileResponse uploadPasswordProtectedCasPdf(
             @RequestPart("file") MultipartFile pdfFile, @RequestPart("password") String password) throws IOException {

--- a/src/main/java/com/app/folioman/portfolio/rest/controllers/PortfolioHistoryController.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/controllers/PortfolioHistoryController.java
@@ -50,6 +50,16 @@ public class PortfolioHistoryController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+    @GetMapping("/{id}/summary")
+    public ResponseEntity<com.app.folioman.portfolio.rest.dtos.PortfolioSummaryDTO> getPortfolioSummary(
+            @PathVariable Long id, Principal principal) {
+        String userEmail = extractUserEmail(principal);
+        return portfolioAPI
+                .getPortfolioSummary(id, userEmail)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
     private String extractUserEmail(Principal principal) {
         if (principal instanceof Authentication authentication) {
             Object authPrincipal = authentication.getPrincipal();

--- a/src/main/java/com/app/folioman/portfolio/rest/dtos/CategoryDTO.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/dtos/CategoryDTO.java
@@ -1,0 +1,9 @@
+package com.app.folioman.portfolio.rest.dtos;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+public record CategoryDTO(String main, String sub) implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/app/folioman/portfolio/rest/dtos/ChangeDTO.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/dtos/ChangeDTO.java
@@ -1,0 +1,13 @@
+package com.app.folioman.portfolio.rest.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serial;
+import java.io.Serializable;
+import org.jspecify.annotations.Nullable;
+
+public record ChangeDTO(
+        @JsonProperty("D") @Nullable Double d,
+        @JsonProperty("A") @Nullable Double a) implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/app/folioman/portfolio/rest/dtos/FolioSummaryDTO.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/dtos/FolioSummaryDTO.java
@@ -1,0 +1,17 @@
+package com.app.folioman.portfolio.rest.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serial;
+import java.io.Serializable;
+import org.jspecify.annotations.Nullable;
+
+public record FolioSummaryDTO(
+        String folio,
+        @Nullable Double invested,
+        @Nullable Double units,
+        @Nullable Double value,
+        @JsonProperty("avg_nav") @Nullable Double avgNav)
+        implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/app/folioman/portfolio/rest/dtos/PortfolioSummaryDTO.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/dtos/PortfolioSummaryDTO.java
@@ -1,0 +1,21 @@
+package com.app.folioman.portfolio.rest.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public record PortfolioSummaryDTO(
+        @Nullable Double invested,
+        @Nullable Double value,
+        @JsonProperty("xirr") XirrDTO xirr,
+        ChangeDTO change,
+        @JsonProperty("change_pct") ChangeDTO changePct,
+        LocalDate date,
+        List<SchemeSummaryDTO> schemes)
+        implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/app/folioman/portfolio/rest/dtos/SchemeSummaryDTO.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/dtos/SchemeSummaryDTO.java
@@ -1,0 +1,30 @@
+package com.app.folioman.portfolio.rest.dtos;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.List;
+import org.jspecify.annotations.Nullable;
+
+public record SchemeSummaryDTO(
+        String id,
+        String name,
+        @Nullable Double xirr,
+        CategoryDTO category,
+        String rta,
+        String plan,
+        @Nullable Double nav0,
+        @Nullable Double nav1,
+        @JsonProperty("nav_date") LocalDate navDate,
+        @Nullable Double invested,
+        @Nullable Double units,
+        @Nullable Double value,
+        @JsonProperty("avg_nav") @Nullable Double avgNav,
+        ChangeDTO change,
+        @JsonProperty("change_pct") ChangeDTO changePct,
+        List<FolioSummaryDTO> folios)
+        implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/java/com/app/folioman/portfolio/rest/dtos/XirrDTO.java
+++ b/src/main/java/com/app/folioman/portfolio/rest/dtos/XirrDTO.java
@@ -1,0 +1,10 @@
+package com.app.folioman.portfolio.rest.dtos;
+
+import java.io.Serial;
+import java.io.Serializable;
+import org.jspecify.annotations.Nullable;
+
+public record XirrDTO(@Nullable Double current, @Nullable Double overall) implements Serializable {
+    @Serial
+    private static final long serialVersionUID = 1L;
+}

--- a/src/main/resources/db/changelog/migration/13-scheme-value.xml
+++ b/src/main/resources/db/changelog/migration/13-scheme-value.xml
@@ -40,4 +40,11 @@
                                  referencedTableSchemaName="portfolio"/>
     </changeSet>
 
+    <changeSet id="1726853021906-4" author="appUser">
+        <createIndex indexName="idx_scheme_value_usd_id_date" schemaName="portfolio" tableName="scheme_value">
+            <column name="user_scheme_detail_id"/>
+            <column name="date" descending="true"/>
+        </createIndex>
+    </changeSet>
+
 </databaseChangeLog>

--- a/src/test/java/com/app/folioman/mfschemes/domain/NewlyInsertedSchemesListenerIT.java
+++ b/src/test/java/com/app/folioman/mfschemes/domain/NewlyInsertedSchemesListenerIT.java
@@ -18,8 +18,11 @@ class NewlyInsertedSchemesListenerIT extends AbstractIntegrationTest {
         List<Long> schemeCodes = List.of(118272L, 120503L);
         UploadedSchemesList event = new UploadedSchemesList(schemeCodes);
 
-        // Publish the event to trigger async processing
-        applicationEventPublisher.publishEvent(event);
+        // Publish the event to trigger async processing within a transaction
+        // so that the @ApplicationModuleListener (which is a @TransactionalEventListener) fires after commit.
+        transactionTemplate.executeWithoutResult(status -> {
+            applicationEventPublisher.publishEvent(event);
+        });
 
         // Record the time before processing to verify new NAVs
         // Widen window to 7 days to include NAVs that may have older navDate values due

--- a/src/test/java/com/app/folioman/portfolio/domain/CapitalGainsHarvestingServiceTest.java
+++ b/src/test/java/com/app/folioman/portfolio/domain/CapitalGainsHarvestingServiceTest.java
@@ -112,6 +112,11 @@ class CapitalGainsHarvestingServiceTest {
             public String getCategory() {
                 return "Equity Scheme";
             }
+
+            @Override
+            public @Nullable String getSubCategory() {
+                return null;
+            }
         };
         MFSchemeProjection schemeProj = new MFSchemeProjection() {
             @Override
@@ -127,6 +132,16 @@ class CapitalGainsHarvestingServiceTest {
             @Override
             public @Nullable MFSchemeTypeProjection getMfSchemeTypeEntity() {
                 return typeProj;
+            }
+
+            @Override
+            public @Nullable String getRta() {
+                return null;
+            }
+
+            @Override
+            public @Nullable String getPlan() {
+                return null;
             }
         };
         when(mfSchemeService.findByAmfiCodeIn(List.of(amfiCode))).thenReturn(List.of(schemeProj));

--- a/src/test/java/com/app/folioman/portfolio/domain/PortfolioSummaryControllerIT.java
+++ b/src/test/java/com/app/folioman/portfolio/domain/PortfolioSummaryControllerIT.java
@@ -58,8 +58,7 @@ class PortfolioSummaryControllerIT extends AbstractIntegrationTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.invested").value(1000.0))
                 .andExpect(jsonPath("$.value").value(1100.0))
-                .andExpect(jsonPath("$.xirr.current")
-                        .doesNotExist()) // Note: the user endpoint uses the projection which has `xirr` for overall
+                .andExpect(jsonPath("$.xirr.current").value(12.5))
                 .andExpect(jsonPath("$.xirr.overall").value(10.5)) // mapped to XirrDTO
                 .andExpect(jsonPath("$.change.D").isNumber())
                 .andExpect(jsonPath("$.change.A").isNumber())

--- a/src/test/java/com/app/folioman/portfolio/domain/PortfolioSummaryControllerIT.java
+++ b/src/test/java/com/app/folioman/portfolio/domain/PortfolioSummaryControllerIT.java
@@ -1,0 +1,141 @@
+package com.app.folioman.portfolio.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.app.folioman.config.redis.CacheNames;
+import com.app.folioman.shared.AbstractIntegrationTest;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Set;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.MediaType;
+
+class PortfolioSummaryControllerIT extends AbstractIntegrationTest {
+
+    @Autowired
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @Test
+    @DisplayName("Should return unauthorized when no authentication token is provided")
+    void shouldReturnUnauthorizedWhenNotAuthenticated() throws Exception {
+        this.mockMvc
+                .perform(get("/api/mutualfunds/portfolio/1/summary").accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("Should return not found when portfolio is not owned by current user")
+    void shouldReturnNotFoundForNonOwnedPortfolio() throws Exception {
+        Long casId = insertTestPortfolioSummaryData("otheruser@example.com");
+
+        this.mockMvc
+                .perform(get("/api/mutualfunds/portfolio/{id}/summary", casId)
+                        .with(testUser())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Should return portfolio summary for owned portfolio and populate cache")
+    void shouldReturnSummaryForOwnedPortfolioAndPopulateCache() throws Exception {
+        String email = "user";
+        Long casId = insertTestPortfolioSummaryData(email);
+
+        // 1. Verify cache is empty initially
+
+        this.mockMvc
+                .perform(get("/api/mutualfunds/portfolio/{id}/summary", casId)
+                        .with(testUser())
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.invested").value(1000.0))
+                .andExpect(jsonPath("$.value").value(1100.0))
+                .andExpect(jsonPath("$.xirr.current")
+                        .doesNotExist()) // Note: the user endpoint uses the projection which has `xirr` for overall
+                .andExpect(jsonPath("$.xirr.overall").value(10.5)) // mapped to XirrDTO
+                .andExpect(jsonPath("$.change.D").isNumber())
+                .andExpect(jsonPath("$.change.A").isNumber())
+                .andExpect(jsonPath("$.change_pct.D").isNumber())
+                .andExpect(jsonPath("$.change_pct.A").isNumber())
+                .andExpect(jsonPath("$.date").exists())
+                .andExpect(jsonPath("$.schemes").isArray())
+                .andExpect(jsonPath("$.schemes[0].nav0").isNumber())
+                .andExpect(jsonPath("$.schemes[0].nav1").isNumber())
+                .andExpect(jsonPath("$.schemes[0].folios").isArray());
+
+        Set<String> cacheKeys = redisTemplate.keys(CacheNames.SUMMARY_CACHE + "::*");
+        assertThat(cacheKeys).isNotNull();
+        assertThat(cacheKeys.stream().anyMatch(key -> key.contains("summary_" + casId + "_")))
+                .isTrue();
+    }
+
+    private Long insertTestPortfolioSummaryData(String email) {
+        return transactionTemplate.execute(status -> {
+            UserCasDetailsEntity casDetails = new UserCasDetailsEntity()
+                    .setCasTypeEnum(CasTypeEnum.DETAILED)
+                    .setFileTypeEnum(FileTypeEnum.CAMS);
+
+            InvestorInfoEntity investorInfo = new InvestorInfoEntity()
+                    .setEmail(email)
+                    .setName("Integration Test User")
+                    .setMobile("9999999999")
+                    .setAddress("Test Address")
+                    .setUserCasDetailsEntity(casDetails);
+
+            casDetails.setInvestorInfoEntity(investorInfo);
+
+            entityManager.persist(casDetails);
+            entityManager.flush();
+            Long casId = casDetails.getId();
+
+            UserPortfolioValueEntity valueEntity = new UserPortfolioValueEntity()
+                    .setDate(LocalDate.now())
+                    .setInvested(BigDecimal.valueOf(1000L))
+                    .setValue(BigDecimal.valueOf(1100L))
+                    .setXirr(BigDecimal.valueOf(10.5))
+                    .setLiveXirr(BigDecimal.valueOf(12.5))
+                    .setUserCasDetails(casDetails);
+            entityManager.persist(valueEntity);
+
+            UserFolioDetailsEntity folio = new UserFolioDetailsEntity()
+                    .setFolio("12345678")
+                    .setAmc("Test AMC")
+                    .setPan("ABCDE1234F")
+                    .setUserCasDetailsEntity(casDetails);
+            entityManager.persist(folio);
+
+            UserSchemeDetailsEntity scheme = new UserSchemeDetailsEntity()
+                    .setScheme("Test Scheme")
+                    .setIsin("INF123456789")
+                    .setAmfi(120503L)
+                    .setUserFolioDetails(folio);
+            entityManager.persist(scheme);
+
+            SchemeValueEntity schemeValue = new SchemeValueEntity()
+                    .setDate(LocalDate.now())
+                    .setInvested(BigDecimal.valueOf(1000L))
+                    .setValue(BigDecimal.valueOf(1100L))
+                    .setBalance(BigDecimal.valueOf(10.0))
+                    .setAvgNav(BigDecimal.valueOf(100.0))
+                    .setUserSchemeDetails(scheme);
+            entityManager.persist(schemeValue);
+
+            FolioSchemeEntity folioScheme = new FolioSchemeEntity()
+                    .setXirr(BigDecimal.valueOf(15.0))
+                    .setUserFolioDetailsEntity(folio)
+                    .setUserSchemeDetailsEntity(scheme);
+            entityManager.persist(folioScheme);
+
+            entityManager.flush();
+            return casId;
+        });
+    }
+}

--- a/src/test/java/com/app/folioman/portfolio/domain/UserSchemeDetailServiceImplTest.java
+++ b/src/test/java/com/app/folioman/portfolio/domain/UserSchemeDetailServiceImplTest.java
@@ -61,6 +61,16 @@ class UserSchemeDetailServiceImplTest {
             public MFSchemeTypeProjection getMfSchemeTypeEntity() {
                 return null;
             }
+
+            @Override
+            public String getRta() {
+                return null;
+            }
+
+            @Override
+            public String getPlan() {
+                return null;
+            }
         };
 
         fundDetailProjection = new FundDetailProjection() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a portfolio summary endpoint (`GET /api/mutualfunds/portfolio/{id}/summary`) returning scheme-level and portfolio-level metrics (last two NAVs, invested/value, changes, XIRR, and folio/category/plan details).
  * Introduced DTO support for the new response and enabled Redis caching for computed summaries.

* **Bug Fixes**
  * Improved summary-cache invalidation so summary data refreshes after mutual fund uploads, matching the latest portfolio contents.

* **Tests**
  * Added integration coverage for authentication/ownership and Redis cache creation for the summary endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->